### PR TITLE
Add help module

### DIFF
--- a/app.R
+++ b/app.R
@@ -31,6 +31,7 @@ source("modules/visualizations_module.R")
 source("modules/research_module.R")
 source("modules/custom_tools_module.R")
 source("modules/gallery_module.R")
+source("modules/help_module.R")
 
 
 ###########################################
@@ -317,7 +318,8 @@ ui <- navbarPage(
   visualizations_module_ui(),
   research_module_ui(),
   custom_tools_module_ui(),
-  gallery_module_ui()
+  gallery_module_ui(),
+  help_module_ui()
 )
 
 ###########################################
@@ -331,6 +333,7 @@ server <- function(input, output, session) {
   research_module_server(input, output, session)
   custom_tools_module_server(input, output, session)
   gallery_module_server(input, output, session)
+  help_module_server(input, output, session)
 }
 
 # Run the app

--- a/modules/help_module.R
+++ b/modules/help_module.R
@@ -1,0 +1,41 @@
+help_module_ui <- function() {
+  tabPanel(
+    "Help",
+    fluidPage(
+      div(
+        style = "max-width:1000px; margin:auto; line-height:1.6; font-size:16px;",
+        h2("Using the Dashboard"),
+        h3("Navigation"),
+        p("Each tab provides access to a different part of the application:"),
+        tags$ul(
+          tags$li(strong("Home:"), " introduction to the project and its aims."),
+          tags$li(strong("Methodology:"), " details on how the bibliometric dataset was compiled."),
+          tags$li(strong("Food AI Review Database:"), " searchable table of the 128 review articles."),
+          tags$li(strong("Review Article Visualisations:"), " interactive plots exploring publication trends and topics."),
+          tags$li(strong("Research Article Analysis:"), " charts generated from the articles cited by the reviews."),
+          tags$li(strong("Custom LLM Tools:"), " links to language model tools trained on this corpus."),
+          tags$li(strong("Image Gallery:"), " collection of AI diagrams from the literature.")
+        ),
+        h3("Data Requirements"),
+        p("Ensure the following files are present in the repository root:"),
+        tags$ul(
+          tags$li(code("FoodAI_Feb2025.bib"), " – bibliographic records for the review articles."),
+          tags$li(code("openalex_minimal.csv"), " – metadata for referenced research articles."),
+          tags$li(code("titles_and_abstracts.csv"), " – titles and abstracts retrieved from OpenAlex.")
+        ),
+        h3("Associated Paper"),
+        p("This dashboard accompanies our systematic review of AI in food science and engineering."),
+        p(
+          tags$a(
+            href = "https://doi.org/10.0000/placeholder",
+            "Read the paper online"
+          )
+        )
+      )
+    )
+  )
+}
+
+help_module_server <- function(input, output, session) {
+  # No server-side logic for the Help tab
+}


### PR DESCRIPTION
## Summary
- add `help_module` with basic navigation guidance
- wire help tab into UI and server

## Testing
- `Rscript --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684af36351288326a9074942b26c449b