### PR TITLE
Add industry case studies dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ Obtained from a February 2025 search of the Web of Science Core Collection and c
 - `FoodAI_Feb2025.bib` – bibliographic records for the 128 review articles analysed in the dashboard. `app.R` now reads this file directly instead of relying on an external CSV.
 - `openalex_minimal.csv` – metadata retrieved from the OpenAlex API for research articles cited by the reviews.
 - `titles_and_abstracts.csv` – matching titles and abstracts from the same OpenAlex query.
+- `case_studies.csv` – ten industry case studies referenced in the review article.
+
+The case studies dataset summarises notable companies applying AI across the food sector, complementing the narrative examples discussed in the paper.
 
 These files were collected as part of the systematic review described in the accompanying paper and should be kept in the repository root so that `app.R` can load them correctly.
 

--- a/app.R
+++ b/app.R
@@ -30,6 +30,7 @@ source("modules/database_module.R")
 source("modules/visualizations_module.R")
 source("modules/research_module.R")
 source("modules/custom_tools_module.R")
+source("modules/case_studies_module.R")
 source("modules/gallery_module.R")
 source("modules/help_module.R")
 
@@ -318,6 +319,7 @@ ui <- navbarPage(
   visualizations_module_ui(),
   research_module_ui(),
   custom_tools_module_ui(),
+  case_studies_module_ui(),
   gallery_module_ui(),
   help_module_ui()
 )
@@ -332,6 +334,7 @@ server <- function(input, output, session) {
   visualizations_module_server(input, output, session)
   research_module_server(input, output, session)
   custom_tools_module_server(input, output, session)
+  case_studies_module_server(input, output, session)
   gallery_module_server(input, output, session)
   help_module_server(input, output, session)
 }

--- a/case_studies.csv
+++ b/case_studies.csv
@@ -1,0 +1,12 @@
+Company,AI_Method,Application_Area
+Shiru,Neural network discovery,Plant-based protein ingredient design
+NotCo,Multi-module AI for flavor pairing and formulation,Plant-based product development
+Brightseed,Machine learning-based discovery,Bioactive compound identification
+Perfect Day,Data-driven strain optimization,Precision fermentation for alternative dairy proteins
+Journey Foods,Ingredient graph analytics,Product formulation insights
+Cargill,Computer vision and robotics,Poultry processing automation
+IBM Food Trust,Blockchain with AI analytics,Supply chain traceability
+PathogenDx,Microarray plus machine learning,Food contamination detection
+Analytical Flavor Systems (Gastrograph AI),Predictive modeling of sensory profiles,Flavor optimization
+Climax Foods,Machine learning-driven formulation,Plant-based cheese development
+

--- a/modules/case_studies_module.R
+++ b/modules/case_studies_module.R
@@ -1,0 +1,22 @@
+case_studies_module_ui <- function() {
+  tabPanel(
+    "Industry Case Studies",
+    fluidPage(
+      titlePanel("Industry Case Studies"),
+      p("Examples of companies applying AI in the food industry."),
+      DT::DTOutput("caseStudiesTable")
+    )
+  )
+}
+
+case_studies_module_server <- function(input, output, session) {
+  case_data <- read.csv("case_studies.csv", stringsAsFactors = FALSE)
+
+  output$caseStudiesTable <- DT::renderDT({
+    DT::datatable(
+      case_data,
+      rownames = FALSE,
+      options = list(pageLength = 10, autoWidth = TRUE)
+    )
+  })
+}


### PR DESCRIPTION
## Summary
- include `case_studies.csv` of ten companies from the review
- display dataset via new `case_studies_module.R`
- load the module in `app.R`
- document the dataset in the README

## Testing
- `Rscript` was unavailable, so the module load check could not run

------
https://chatgpt.com/codex/tasks/task_e_684af54bc1108326b08e70bac3f0f435