### PR TITLE
Add dark mode toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains a Shiny application for interactively exploring bibliom
 
 The app relies on several R packages:
 
-- shiny, shinythemes, shinycssloaders
+- shiny, bslib, shinycssloaders
 - memoise
 - dplyr, tidyr, widyr
 - ggplot2, plotly, ggwordcloud
@@ -33,6 +33,8 @@ shiny::runApp()
 ```
 
 Both commands launch the local Shiny server and open the dashboard in your browser.
+
+Use the toggle in the navigation bar to switch between light and dark themes during runtime.
 
 ## Downloading Data and Plots
 

--- a/app.R
+++ b/app.R
@@ -2,7 +2,7 @@
 ## app.R
 ###########################################
 library(shiny)
-library(shinythemes)
+library(bslib)
 library(memoise)
 library(dplyr)
 library(DT)
@@ -309,10 +309,14 @@ tidy_dtm <- tidy(dtm) # yields columns: document, term, count
 ###########################################
 ## 2) UI
 ###########################################
+light_theme <- bs_theme(version = 5, bootswatch = "flatly")
+dark_theme  <- bs_theme(version = 5, bootswatch = "darkly")
+
 k <- 6  # for LDA topics
 ui <- navbarPage(
   title = "Food AI Review App",
-  theme = shinytheme("flatly"),
+  theme = light_theme,
+  header = div(class = "ms-auto me-3", input_dark_mode("theme_toggle")),
   home_module_ui(),
   methodology_module_ui(),
   tabPanel("Food AI Review Database", database_module_ui()),
@@ -328,6 +332,11 @@ ui <- navbarPage(
 ## 3) SERVER
 ###########################################
 server <- function(input, output, session) {
+  observeEvent(input$theme_toggle, {
+    session$setCurrentTheme(
+      if (identical(input$theme_toggle, "dark")) dark_theme else light_theme
+    )
+  })
   home_module_server(input, output, session)
   methodology_module_server(input, output, session)
   database_module_server(input, output, session)


### PR DESCRIPTION
## Summary
- use **bslib** to add runtime theme switching
- expose a dark/light toggle in the navbar
- document the new feature and dependency in the README

## Testing
- `R -q -e "sessionInfo()"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bc1e55ec483269bf8e8ed5e58bd31